### PR TITLE
add dlLoad flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(UNIX)
         int main() {
             void* handle = dlopen(\"path\", RTLD_NOW | RTLD_GLOBAL);
             void* func = dlsym(handle, \"name\");
+            (void)func;
             (void)dlclose(handle);
         }"
         can_use_dlopen)
@@ -45,6 +46,7 @@ elseif(WIN32)
         int main() {
             void* handle = LoadLibraryExA((LPCSTR)\"\", (HANDLE)NULL, (DWORD)0);
             void* func = GetProcAddress((HMODULE)handle, (LPCSTR)\"\");
+            (void)func;
             (void)FreeLibrary((HMODULE)handle);
         }"
         can_use_LoadLibrary)

--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ using Func = int (*)(int)
 int main()
 {
     // create a handle to the shared library
-    // equivalent to :
-    // Windows : LoadLibraryExA((LPCSTR)"path/to/myLib.dll", (HANDLE)NULL, (DWORD)0);
-    // Unix : dlopen("path/to/myLib.dll", RTLD_NOW | RTLD_GLOBAL);
-    DlHandle handle = dlLoad("path/to/myLib.dll");
+    DlHandle handle = dlLoad("path/to/myLib.dll", DL_NOW | DL_LOCAL);
 
     // retrive a function pointer to the desired function in the library
     Func f = (Func)getSym(handle, "myFunction");
@@ -59,3 +56,19 @@ int main()
     dlFree(handle);
 }
 ````
+
+Load flags
+----------
+
+`dlLoad()` takes a bitmask of flags:
+
+```cpp
+DlHandle handle = dlLoad("path/to/myLib.dll", DL_NOW | DL_LOCAL);
+```
+
+| dlLoad flags | Unix equivalent | Windows equivalent |
+|--------------|-----------------|--------------------|
+| `DL_LAZY`    | `RTLD_LAZY`     | `0`                |
+| `DL_NOW`     | `RTLD_NOW`      | `0`                |
+| `DL_GLOBAL`  | `RTLD_GLOBAL`   | `0`                |
+| `DL_LOCAL`   | `RTLD_LOCAL`    | `0`                |

--- a/include/dlLoad/dlLoad.h
+++ b/include/dlLoad/dlLoad.h
@@ -16,10 +16,16 @@ extern "C"
 #endif
 
 typedef void* DlHandle;
+typedef unsigned int DlLoadFlags;
 
 #define DL_DEFAULT (DlHandle)0
 
-DlHandle dlLoad(const char* path);
+#define DL_LAZY   ((DlLoadFlags)1u << 0)
+#define DL_NOW    ((DlLoadFlags)1u << 1)
+#define DL_GLOBAL ((DlLoadFlags)1u << 2)
+#define DL_LOCAL  ((DlLoadFlags)1u << 3)
+
+DlHandle dlLoad(const char* path, DlLoadFlags flags);
 void* getSym(DlHandle handle, const char* name);
 int dlFree(DlHandle handle);
 

--- a/src/dlLoad_unix.c
+++ b/src/dlLoad_unix.c
@@ -8,11 +8,52 @@
  */
 
 #include "dlLoad/dlLoad.h"
+#include <stddef.h>
 #include <dlfcn.h>
 
-DlHandle dlLoad(const char* path)
+static int getNativeFlags(DlLoadFlags flags)
 {
-    return dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+    int nativeFlags = 0;
+    DlLoadFlags knownFlags[] = {
+        DL_LAZY,
+        DL_NOW,
+        DL_GLOBAL,
+        DL_LOCAL
+    };
+    size_t i = 0;
+
+    for (i = 0; i < sizeof(knownFlags) / sizeof(knownFlags[0]); i++)
+    {
+        DlLoadFlags knownFlag = knownFlags[i];
+
+        if ((flags & knownFlag) == 0)
+            continue;
+
+        switch (knownFlag)
+        {
+        case DL_LAZY:
+            nativeFlags |= RTLD_LAZY;
+            break;
+        case DL_NOW:
+            nativeFlags |= RTLD_NOW;
+            break;
+        case DL_GLOBAL:
+            nativeFlags |= RTLD_GLOBAL;
+            break;
+        case DL_LOCAL:
+            nativeFlags |= RTLD_LOCAL;
+            break;
+        default:
+            break;
+        }
+    }
+
+    return nativeFlags;
+}
+
+DlHandle dlLoad(const char* path, DlLoadFlags flags)
+{
+    return dlopen(path, getNativeFlags(flags));
 }
 
 void* getSym(DlHandle handle, const char* name)

--- a/src/dlLoad_win.c
+++ b/src/dlLoad_win.c
@@ -8,10 +8,11 @@
  */
 
 #include "dlLoad/dlLoad.h"
-#include "Windows.h"
+#include <Windows.h>
 
-DlHandle dlLoad(const char* path)
+DlHandle dlLoad(const char* path, DlLoadFlags flags)
 {
+    (void)flags;
     return LoadLibraryExA((LPCSTR)path, (HANDLE)NULL, (DWORD)0);
 }
 

--- a/tests/dlLoad_testWithStaticLib/dlLoad_withStaticLib_testCases.cpp
+++ b/tests/dlLoad_testWithStaticLib/dlLoad_withStaticLib_testCases.cpp
@@ -22,7 +22,7 @@ TEST(dlLoadTestWithStaticLib, mainExeClassConstructor)
 {
     using Func = StaticLibClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -41,7 +41,7 @@ TEST(dlLoadTestWithStaticLib, mainExeFunc)
 {
     using Func = StaticLibClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");

--- a/tests/dlLoad_testWithStaticLib/dlLoad_withStaticLib_testCases.cpp
+++ b/tests/dlLoad_testWithStaticLib/dlLoad_withStaticLib_testCases.cpp
@@ -22,7 +22,7 @@ TEST(dlLoadTestWithStaticLib, mainExeClassConstructor)
 {
     using Func = StaticLibClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_4_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -41,7 +41,7 @@ TEST(dlLoadTestWithStaticLib, mainExeFunc)
 {
     using Func = StaticLibClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_4_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_4_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");

--- a/tests/dlLoad_tests/dlLoad_testCases.cpp
+++ b/tests/dlLoad_tests/dlLoad_testCases.cpp
@@ -16,7 +16,7 @@ TEST(dlLoadTest, voidFuncNoArg)
 {
     using Func = void (*)();
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -31,7 +31,7 @@ TEST(dlLoadTest, intFuncNoArg)
 {
     using Func = int (*)();
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");
@@ -46,7 +46,7 @@ TEST(dlLoadTest, intFuncIntArg)
 {
     using Func = int (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function3");
@@ -62,7 +62,7 @@ TEST(dlLoadTest, sizetFuncStrArg)
 {
     using Func = size_t (*)(const std::string&);
 
-    DlHandle handle = dlLoad(TEST_LIB_2_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_2_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -88,7 +88,7 @@ TEST(dlLoadTest, mainExeClassConstructor)
 {
     using Func = TestClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -107,7 +107,7 @@ TEST(dlLoadTest, mainExeFunc)
 {
     using Func = TestClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_LOCAL);
+    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_NOW | DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");

--- a/tests/dlLoad_tests/dlLoad_testCases.cpp
+++ b/tests/dlLoad_tests/dlLoad_testCases.cpp
@@ -16,7 +16,7 @@ TEST(dlLoadTest, voidFuncNoArg)
 {
     using Func = void (*)();
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -31,7 +31,7 @@ TEST(dlLoadTest, intFuncNoArg)
 {
     using Func = int (*)();
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");
@@ -46,7 +46,7 @@ TEST(dlLoadTest, intFuncIntArg)
 {
     using Func = int (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function3");
@@ -62,7 +62,7 @@ TEST(dlLoadTest, sizetFuncStrArg)
 {
     using Func = size_t (*)(const std::string&);
 
-    DlHandle handle = dlLoad(TEST_LIB_2_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_2_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -88,7 +88,7 @@ TEST(dlLoadTest, mainExeClassConstructor)
 {
     using Func = TestClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_3_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function1");
@@ -107,7 +107,7 @@ TEST(dlLoadTest, mainExeFunc)
 {
     using Func = TestClass* (*)(int);
 
-    DlHandle handle = dlLoad(TEST_LIB_3_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_3_FILE, DL_LOCAL);
     ASSERT_NE(handle, nullptr);
 
     Func f = (Func)getSym(handle, "function2");

--- a/tests/testLibs/testLib5.cpp
+++ b/tests/testLibs/testLib5.cpp
@@ -26,7 +26,7 @@ int dyload_function2()
 {
     using Func = int (*)(void);
 
-    DlHandle handle = dlLoad(TEST_LIB_1_FILE);
+    DlHandle handle = dlLoad(TEST_LIB_1_FILE, DL_NOW | DL_LOCAL);
     if (handle == nullptr)
         return -1;
 


### PR DESCRIPTION
This pull request refactors the dynamic library loading API to support explicit loading flags, improving flexibility and cross-platform compatibility. The main changes include updating the `dlLoad` function to accept a bitmask of flags, updating all usages and documentation accordingly, and ensuring the correct mapping of these flags to native equivalents on both Unix and Windows. Tests and documentation have been updated to reflect the new API.

**API and Core Functionality Updates:**

* Added `DlLoadFlags` type and defined flag constants (`DL_LAZY`, `DL_NOW`, `DL_GLOBAL`, `DL_LOCAL`) in `dlLoad/dlLoad.h`. Updated the `dlLoad` function signature to accept a flags argument.
* Refactored Unix implementation to translate `DlLoadFlags` to the appropriate `dlopen` flags.
* Updated Windows implementation of `dlLoad` to accept the new flags parameter (currently ignored, as Windows does not support these flags).

**Documentation Improvements:**

* Updated the `README.md` to document the new flags parameter, provide usage examples, and include a table mapping `DlLoadFlags` to their Unix and Windows equivalents. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R74)

**Test and Usage Updates:**

* Updated all usages of `dlLoad` in tests and examples to include the required flags. [[1]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L19-R19) [[2]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L34-R34) [[3]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L49-R49) [[4]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L65-R65) [[5]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L91-R91) [[6]](diffhunk://#diff-10e4c309b45875e2fcc74a311b729f638b0113fa1059c4b2529906aea68293e1L110-R110) [[7]](diffhunk://#diff-02d38cd62e481ba723c03139713553f5a54d30afe7a4e0fd5f2a51c64dd7e28fL25-R25) [[8]](diffhunk://#diff-02d38cd62e481ba723c03139713553f5a54d30afe7a4e0fd5f2a51c64dd7e28fL44-R44) [[9]](diffhunk://#diff-fcd0891e5ae8660be4c78a4fd93854c547f2707ef99c13ad9c56cef43e972f9fL29-R29)

**Build System and Code Hygiene:**

* Fixed minor issues in CMake test code to avoid unused variable warnings. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR38) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR53)